### PR TITLE
add missing accountType for EnableSessionData for decodeSmartSessionSignature

### DIFF
--- a/src/module/smart-sessions/abi.ts
+++ b/src/module/smart-sessions/abi.ts
@@ -304,7 +304,7 @@ export const encodeEnableSessionSignatureAbi = [
     type: 'tuple',
   },
   { type: 'bytes' },
-]
+] as const
 
 export const abi = [
   {

--- a/src/module/smart-sessions/usage.ts
+++ b/src/module/smart-sessions/usage.ts
@@ -241,7 +241,7 @@ export const decodeSmartSessionSignature = ({
       const decodedData = decodeAbiParameters(
         encodeEnableSessionSignatureAbi,
         data,
-      ) as any
+      ) 
       const enableSession = decodedData[0]
 
       const permissionEnableSigSlice = account.type === 'kernel' ? 1 : 0
@@ -266,7 +266,8 @@ export const decodeSmartSessionSignature = ({
             permissionEnableSig: permissionEnableSig,
           },
           validator: validator,
-        },
+          accountType: account.type,
+        } as EnableSessionData
       }
     default:
       throw new Error(`Unknown mode ${mode}`)

--- a/src/module/smart-sessions/usage.ts
+++ b/src/module/smart-sessions/usage.ts
@@ -245,6 +245,9 @@ export const decodeSmartSessionSignature = ({
       const enableSession = decodedData[0]
 
       const permissionEnableSigSlice = account.type === 'kernel' ? 1 : 0
+      if(account.type === 'kernel' && !enableSession.permissionEnableSig.startsWith('0x01')) {
+        throw new Error('Invalid permissionEnableSig for kernel account')
+      }
       const permissionEnableSig = slice(
         enableSession.permissionEnableSig,
         20 + permissionEnableSigSlice,

--- a/test/unit/module/smartSessions/smartSessionsValidator.test.ts
+++ b/test/unit/module/smartSessions/smartSessionsValidator.test.ts
@@ -172,4 +172,199 @@ describe('Smart Sessions Polices', () => {
     )
     expect(decodedSig.enableSessionData?.accountType).toEqual(account.type)
   })
+
+  it('should correctly encode and decode the session signature in enable mode for kernel', async () => {
+    const permissionId = keccak256(toHex('permissionId'))
+    const sigHash = keccak256(toHex('sigHash'))
+    const permissionEnableHash = keccak256(toHex('permissionEnableHash'))
+
+    const privateKey = generatePrivateKey()
+    const signer = privateKeyToAccount(privateKey)
+
+    const client = createWalletClient({
+      account: signer,
+      chain: mainnet,
+      transport: http(),
+    })
+
+    const signature = await client.signMessage({
+      message: { raw: sigHash },
+    })
+
+    const permissionEnableSig = await signer.signMessage({
+      message: { raw: permissionEnableHash },
+    })
+
+    const account = getAccount({
+      address: '0x7227dcfb0c5ec7a5f539f97b18be261c49687ed6',
+      type: 'kernel',
+    })
+
+    const session: Session = {
+      sessionValidator: OWNABLE_VALIDATOR_ADDRESS as Address,
+      sessionValidatorInitData: encodeValidationData({
+        threshold: 1,
+        owners: [privateKeyToAccount(privateKey).address],
+      }),
+      salt: toHex(toBytes('1', { size: 32 })),
+      userOpPolicies: [],
+      actions: [
+        {
+          actionTarget: getAddress(account.address),
+          actionTargetSelector: '0x9cfd7cff' as Hex,
+          actionPolicies: [
+            {
+              policy: getAddress(getSudoPolicy().address),
+              initData: getSudoPolicy().initData,
+            },
+          ],
+        },
+      ],
+      erc7739Policies: {
+        allowedERC7739Content: [],
+        erc1271Policies: [],
+      },
+    }
+
+    const sessionDigest = keccak256(toHex('sessionDigest'))
+
+    const chainDigests = [
+      {
+        chainId: BigInt(mainnet.id),
+        sessionDigest,
+      },
+    ]
+
+    const encodedSig = encodeSmartSessionSignature({
+      mode: SmartSessionMode.ENABLE,
+      permissionId,
+      signature,
+      enableSessionData: {
+        enableSession: {
+          chainDigestIndex: 0,
+          hashesAndChainIds: chainDigests,
+          sessionToEnable: session,
+          permissionEnableSig,
+        },
+        validator: OWNABLE_VALIDATOR_ADDRESS,
+        accountType: account.type,
+      },
+    })
+
+    const decodedSig = decodeSmartSessionSignature({
+      signature: encodedSig,
+      account,
+    })
+
+    expect(decodedSig.mode).toEqual(SmartSessionMode.ENABLE)
+    expect(decodedSig.permissionId).toEqual(permissionId)
+    expect(decodedSig.signature).toEqual(signature)
+    expect(
+      decodedSig.enableSessionData?.enableSession.chainDigestIndex,
+    ).toEqual(0)
+    expect(
+      decodedSig.enableSessionData?.enableSession.hashesAndChainIds,
+    ).toEqual(chainDigests)
+    expect(decodedSig.enableSessionData?.enableSession.sessionToEnable).toEqual(
+      session,
+    )
+    expect(
+      decodedSig.enableSessionData?.enableSession.permissionEnableSig,
+    ).toEqual(permissionEnableSig)
+    expect(keccak256(decodedSig.enableSessionData?.validator!)).toEqual(
+      keccak256(OWNABLE_VALIDATOR_ADDRESS),
+    )
+    expect(decodedSig.enableSessionData?.accountType).toEqual(account.type)
+  })
+
+  it('should throw error when decoding the session signature in enable mode with incorrect account', async () => {
+    const permissionId = keccak256(toHex('permissionId'))
+    const sigHash = keccak256(toHex('sigHash'))
+    const permissionEnableHash = keccak256(toHex('permissionEnableHash'))
+
+    const privateKey = generatePrivateKey()
+    const signer = privateKeyToAccount(privateKey)
+
+    const client = createWalletClient({
+      account: signer,
+      chain: mainnet,
+      transport: http(),
+    })
+
+    const signature = await client.signMessage({
+      message: { raw: sigHash },
+    })
+
+    const permissionEnableSig = await signer.signMessage({
+      message: { raw: permissionEnableHash },
+    })
+
+    const account = getAccount({
+      address: '0x7227dcfb0c5ec7a5f539f97b18be261c49687ed6',
+      type: 'erc7579-implementation',
+    })
+
+    const session: Session = {
+      sessionValidator: OWNABLE_VALIDATOR_ADDRESS as Address,
+      sessionValidatorInitData: encodeValidationData({
+        threshold: 1,
+        owners: [privateKeyToAccount(privateKey).address],
+      }),
+      salt: toHex(toBytes('1', { size: 32 })),
+      userOpPolicies: [],
+      actions: [
+        {
+          actionTarget: getAddress(account.address),
+          actionTargetSelector: '0x9cfd7cff' as Hex,
+          actionPolicies: [
+            {
+              policy: getAddress(getSudoPolicy().address),
+              initData: getSudoPolicy().initData,
+            },
+          ],
+        },
+      ],
+      erc7739Policies: {
+        allowedERC7739Content: [],
+        erc1271Policies: [],
+      },
+    }
+
+    const sessionDigest = keccak256(toHex('sessionDigest'))
+
+    const chainDigests = [
+      {
+        chainId: BigInt(mainnet.id),
+        sessionDigest,
+      },
+    ]
+
+    const encodedSig = encodeSmartSessionSignature({
+      mode: SmartSessionMode.ENABLE,
+      permissionId,
+      signature,
+      enableSessionData: {
+        enableSession: {
+          chainDigestIndex: 0,
+          hashesAndChainIds: chainDigests,
+          sessionToEnable: session,
+          permissionEnableSig,
+        },
+        validator: OWNABLE_VALIDATOR_ADDRESS,
+        accountType: account.type,
+      },
+    })
+
+    const wrongAccount = getAccount({
+      address: '0x7227dcfb0c5ec7a5f539f97b18be261c49687ed6',
+      type: 'kernel',
+    }) 
+    
+    expect(() => decodeSmartSessionSignature({
+      signature: encodedSig,
+      account: wrongAccount,
+    })).toThrow('Invalid permissionEnableSig for kernel account');
+
+  })
+
 })

--- a/test/unit/module/smartSessions/smartSessionsValidator.test.ts
+++ b/test/unit/module/smartSessions/smartSessionsValidator.test.ts
@@ -170,5 +170,6 @@ describe('Smart Sessions Polices', () => {
     expect(keccak256(decodedSig.enableSessionData?.validator!)).toEqual(
       keccak256(OWNABLE_VALIDATOR_ADDRESS),
     )
+    expect(decodedSig.enableSessionData?.accountType).toEqual(account.type)
   })
 })


### PR DESCRIPTION
I thought it would be helpful for the `decodeSmartSessionSignature` method to return the complete `EnableSessionData`, so I added the missing `accountType`.

As for the ABIs, I noticed they weren't cast as `const`, which could be intentional. However, casting them as `const` provides proper types when using `decodeAbiParameters`, so I added this to `encodeEnableSessionSignatureAbi`. If necessary, we can apply this to the other ABIs as well.