### PR TITLE
export moduleTypeIds, add findTrustAttesters, and update getSmartSessionsValidator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export type { Account, AccountType, Execution, InitialModules } from './account'
 
 // Module
 export {
+  moduleTypeIds,
   getModule,
   MULTI_FACTOR_VALIDATOR_ADDRESS,
   getMultiFactorValidator,

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export {
   getFlashloanWhitelist,
   fetchRegistryModules,
   getTrustAttestersAction,
-  findTrustAttesters,
+  findTrustedAttesters,
   REGISTRY_ADDRESS,
   RHINESTONE_ATTESTER_ADDRESS,
   MOCK_ATTESTER_ADDRESS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ export {
   getFlashloanWhitelist,
   fetchRegistryModules,
   getTrustAttestersAction,
+  findTrustAttesters,
   REGISTRY_ADDRESS,
   RHINESTONE_ATTESTER_ADDRESS,
   MOCK_ATTESTER_ADDRESS,

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -151,7 +151,7 @@ export {
 export {
   fetchRegistryModules,
   getTrustAttestersAction,
-  findTrustAttesters,
+  findTrustedAttesters,
   REGISTRY_ADDRESS,
   MOCK_ATTESTER_ADDRESS,
   RHINESTONE_ATTESTER_ADDRESS,

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -164,3 +164,5 @@ export type {
   SigHookInit,
   Validator,
 } from './types'
+
+export { moduleTypeIds } from './types'

--- a/src/module/index.ts
+++ b/src/module/index.ts
@@ -150,8 +150,9 @@ export {
 
 export {
   fetchRegistryModules,
-  REGISTRY_ADDRESS,
   getTrustAttestersAction,
+  findTrustAttesters,
+  REGISTRY_ADDRESS,
   MOCK_ATTESTER_ADDRESS,
   RHINESTONE_ATTESTER_ADDRESS,
 } from './registry'

--- a/src/module/registry/abi.ts
+++ b/src/module/registry/abi.ts
@@ -821,4 +821,4 @@ export const abi = [
     stateMutability: 'nonpayable',
     type: 'function',
   },
-]
+] as const

--- a/src/module/registry/index.ts
+++ b/src/module/registry/index.ts
@@ -1,4 +1,4 @@
-export { fetchRegistryModules, getTrustAttestersAction, findTrustAttesters } from './usage'
+export { fetchRegistryModules, getTrustAttestersAction, findTrustedAttesters } from './usage'
 export {
   REGISTRY_ADDRESS,
   MOCK_ATTESTER_ADDRESS,

--- a/src/module/registry/index.ts
+++ b/src/module/registry/index.ts
@@ -1,4 +1,4 @@
-export { fetchRegistryModules, getTrustAttestersAction } from './usage'
+export { fetchRegistryModules, getTrustAttestersAction, findTrustAttesters } from './usage'
 export {
   REGISTRY_ADDRESS,
   MOCK_ATTESTER_ADDRESS,

--- a/src/module/registry/usage.ts
+++ b/src/module/registry/usage.ts
@@ -25,7 +25,7 @@ export const getTrustAttestersAction = ({
   }
 }
 
-export const findTrustAttesters = async ({
+export const findTrustedAttesters = async ({
   client, 
   accountAddress
 }: {

--- a/src/module/registry/usage.ts
+++ b/src/module/registry/usage.ts
@@ -24,3 +24,18 @@ export const getTrustAttestersAction = ({
     }),
   }
 }
+
+export const findTrustAttesters = async ({
+  client, 
+  accountAddress
+}: {
+  client:PublicClient, 
+  accountAddress:Address
+}) => {
+  return await client.readContract({
+    address: REGISTRY_ADDRESS,
+    abi,
+    functionName: 'findTrustedAttesters',
+    args: [accountAddress]
+  }) as Address[]
+}

--- a/src/module/smart-sessions/installation.ts
+++ b/src/module/smart-sessions/installation.ts
@@ -5,7 +5,7 @@ import { Session } from './types'
 import { installSmartSessionsAbi } from './abi'
 
 type Params = {
-  sessions: Session[]
+  sessions?: Session[]
   hook?: Address
 }
 
@@ -15,7 +15,7 @@ export const getSmartSessionsValidator = ({
 }: Params): Module => {
   return {
     module: SMART_SESSIONS_ADDRESS,
-    initData: encodeAbiParameters(installSmartSessionsAbi, [sessions]),
+    initData: sessions ? encodeAbiParameters(installSmartSessionsAbi, [sessions]) : '0x',
     deInitData: '0x',
     additionalContext: '0x',
     type: 'validator',


### PR DESCRIPTION
- exported moduleTypeIds
- added and exported findTrustAttesters - need to get existing trustedAttesters for the account
- updated getSmartSessionsValidator - making sessions params as optionals