### PR TITLE
fix: encodeUseOrEnableSmartSessionSignature method

### DIFF
--- a/src/module/smart-sessions/usage.ts
+++ b/src/module/smart-sessions/usage.ts
@@ -204,10 +204,9 @@ export const encodeUseOrEnableSmartSessionSignature = async ({
         ],
       )
     : encodePacked(
-        ['bytes1', 'bytes32', 'bytes'],
+        ['bytes1', 'bytes'],
         [
           SmartSessionMode.ENABLE,
-          permissionId,
           LibZip.flzCompress(
             encodeEnableSessionSignature({ enableSessionData, signature }),
           ) as Hex,


### PR DESCRIPTION
based on updates done perviously but I guess it was missed `removing permissionId when encoding the Enable signature`