### PR TITLE
Fix method `encodeUseOrEnableSmartSessionSignature` for USE Mode

### DIFF
--- a/src/module/smart-sessions/usage.ts
+++ b/src/module/smart-sessions/usage.ts
@@ -268,16 +268,7 @@ export const encodeUseOrEnableSmartSessionSignature = async ({
         [
           SmartSessionMode.USE,
           permissionId,
-          LibZip.flzCompress(
-            encodeAbiParameters(
-              [
-                {
-                  type: 'bytes',
-                },
-              ],
-              [signature],
-            ),
-          ) as Hex,
+          signature,
         ],
       )
     : encodePacked(


### PR DESCRIPTION
Fix the `encodeUseOrEnableSmartSessionSignature` method for `USE` mode.
From the contract, it seems that signature compression is not needed for `USE` mode.